### PR TITLE
feat/#135-reset-password-page

### DIFF
--- a/src/components/login/organisms/IdentificationForm.tsx
+++ b/src/components/login/organisms/IdentificationForm.tsx
@@ -1,13 +1,21 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import { useRouter } from "next/navigation";
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
+import Backdrop from "@/components/common/Backdrop";
 
 interface userIdentificationDto {
   email: string;
   phone: string;
+}
+
+interface verificationDto {
+  email: string;
+  phoneNumber: string;
+  code: string;
 }
 
 export default function IdentificationForm() {
@@ -25,10 +33,43 @@ export default function IdentificationForm() {
 
   // 본인 인증 에러 메시지를 위한 상태 추가
   const [identificationError, setIdentificationError] = useState("");
+  const [showModal, setShowModal] = useState(false); // 모달 표시 상태 추가
+  const [mounted, setMounted] = useState(false);
+  const [timeLeft, setTimeLeft] = useState(180); // 3분 = 180초
+  const [verificationError, setVerificationError] = useState("");
+  const [verificationCode, setVerificationCode] = useState("");
 
-  // 모달 표시 상태 추가
-  const [showModal, setShowModal] = useState(false);
-  
+  useEffect(() => {
+    setMounted(true);
+    return () => setMounted(false);
+  }, []);
+
+  useEffect(() => {
+    if (showModal) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'unset';
+    }
+    return () => {
+      document.body.style.overflow = 'unset';
+    };
+  }, [showModal]);
+
+  useEffect(() => {
+    if (showModal && timeLeft > 0) {
+      const timer = setInterval(() => {
+        setTimeLeft((prev) => prev - 1);
+      }, 1000);
+      return () => clearInterval(timer);
+    }
+  }, [showModal, timeLeft]);
+
+  const formatTime = (seconds: number) => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
   // 입력값 유효성 검사 함수
   const validateForm = () => {
     let isValid = true;
@@ -55,14 +96,21 @@ export default function IdentificationForm() {
     return isValid;
   };
 
+  const resetModalState = () => {
+    setShowModal(false);
+    setTimeLeft(180); // 타이머 초기화
+    setVerificationError(""); // 에러 메시지 초기화
+    setVerificationCode(""); // 인증번호 입력값 초기화
+  };
+
   const handleIdentify = async (e: React.FormEvent) => {
     e.preventDefault();
 
-      // 본인인증 시도 시 이전 에러 메시지 초기화
-      setIdentificationError("");
+    // 본인인증 시도 시 이전 에러 메시지 초기화
+    setIdentificationError("");
 
-     // 폼 데이터 확인을 위한 콘솔 로그
-     console.log("본인인증 시도:", {
+    // 폼 데이터 확인을 위한 콘솔 로그
+    console.log("본인인증 시도:", {
       이메일: formData.email,
       전화번호: formData.phone,
     });
@@ -95,72 +143,192 @@ export default function IdentificationForm() {
     }
 
     if (response.ok) {
-      // replace("/login/reset");
+      setShowModal(true); // 성공 시 모달 표시
       console.log("본인인증 성공");
     } else {
       refresh(); // 실패 시 현재 페이지 새로고침
     }
   };
 
+  const handleVerification = async (e?: React.MouseEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
+
+    // 인증 번호 입력 시도 시 이전 에러 메시지 초기화
+    setVerificationError("");
+
+    // 타이머 만료 체크를 먼저 수행
+    if (timeLeft <= 0) {
+      setVerificationError("인증 시간이 만료되었습니다. 인증번호를 다시 요청해주세요.");
+      return;
+    }
+
+    // 그 다음 인증번호 빈 값 체크
+    if (!verificationCode.trim()) {
+      setVerificationError("인증번호를 입력해주세요.");
+      return;
+    }
+
+    // 폼 데이터 확인을 위한 콘솔 로그
+    console.log("인증 번호 입력:", {
+      이메일: formData.email,
+      전화번호: formData.phone,
+      인증번호: verificationCode,
+    });
+
+    const verificationData: verificationDto = {
+      email: formData.email,
+      phoneNumber: formData.phone,
+      code: verificationCode
+    };
+
+    const response = await fetch(`/api/server/member/validation`, {
+      method: "POST",
+      body: JSON.stringify(verificationData),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    // API 응답 확인을 위한 콘솔 로그
+    console.log("API 응답 상태:", response.status);
+
+    // 인증번호 인증 실패 시 에러 처리
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      setVerificationError("인증번호가 일치하지 않습니다.");
+      console.error("인증번호 인증 실패:", errorMessage);
+      return;
+    }
+
+    if (response.ok) {
+      console.log("인증번호 인증 성공");
+      replace("/login/reset"); // 바로 페이지 이동
+    } else {
+      refresh(); // 실패 시 현재 페이지 새로고침
+    }
+};
+
   return (
-    <div className="p-8 rounded-4xl shadow bg-gray-0">
-      <form onSubmit={handleIdentify} className="space-y-[38px] w-[530px] py-6">
-        <h2 className="h1 text-center font-bold text-gray-1000">
-          {"본인확인"}
-        </h2>
-        <div className="space-y-4">
-          {/* <Input name="name" type="text" placeholder="이름" />
-          <Input name="company" type="text" placeholder="기업명" />
-          <Input name="carrier" type="text" placeholder="통신사" /> */}
-               <div>
-            <Input 
-              name="email" 
-              type="text" 
-              placeholder="아이디(이메일)"
-              currentValue={formData.email}
-              handleInputChange={(e) =>
-                setFormData((prev) => ({
-                  ...prev,
-                  email: e.target.value,
-                }))
-              }
-            />
-            {errors.email && (
-              <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
-                {errors.email}
-              </p>
-            )}
+    <>
+      <div className="p-8 rounded-4xl shadow bg-gray-0">
+        <form onSubmit={handleIdentify} className="space-y-[38px] w-[530px] py-6">
+          <h2 className="h1 text-center font-bold text-gray-1000">
+            {"본인확인"}
+          </h2>
+          <div className="space-y-4">
+            {/* <Input name="name" type="text" placeholder="이름" />
+            <Input name="company" type="text" placeholder="기업명" />
+            <Input name="carrier" type="text" placeholder="통신사" /> */}
+            <div>
+              <Input 
+                name="email" 
+                type="text" 
+                placeholder="아이디(이메일)"
+                currentValue={formData.email}
+                handleInputChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    email: e.target.value,
+                  }))
+                }
+              />
+              {errors.email && (
+                <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
+                  {errors.email}
+                </p>
+              )}
+            </div>
+            <div>
+              <Input 
+                name="phone" 
+                type="text" 
+                placeholder="핸드폰 번호"
+                currentValue={formData.phone}
+                handleInputChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    phone: e.target.value,
+                  }))
+                }
+              />
+              {errors.phone && (
+                <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
+                  {errors.phone}
+                </p>
+              )}
+                {/* 본인인증 에러 메시지를 전화번호 필드 아래에 표시 */}
+                {identificationError && (
+                <p
+                  className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}
+                >
+                  {identificationError}
+                </p>
+              )}
+            </div>
           </div>
-          <div>
-            <Input 
-              name="phone" 
-              type="text" 
-              placeholder="핸드폰 번호"
-              currentValue={formData.phone}
-              handleInputChange={(e) =>
-                setFormData((prev) => ({
-                  ...prev,
-                  phone: e.target.value,
-                }))
-              }
-            />
-            {errors.phone && (
-              <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
-                {errors.phone}
-              </p>
-            )}
-              {/* 본인인증 에러 메시지를 전화번호 필드 아래에 표시 */}
-              {identificationError && (
-              <p
-                className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}
-              >
-                {identificationError}
-              </p>
-            )}
+          <Button content="인증번호 전송" primary />
+        </form>
+      </div>
+
+      {mounted && showModal && createPortal(
+        <div className="fixed inset-0 w-screen h-screen bg-black/50 z-[9999]">
+          <Backdrop modalId="identification-modal" handleClose={resetModalState} />
+          <div className="fixed inset-0 flex items-center justify-center z-[10000]">
+            <div className="relative w-[594px] p-[32px] rounded-4xl shadow bg-gray-0">
+              <div className="relative h-[88px] flex flex-col justify-center items-center border-b border-gray-100">
+                <div>
+                  <div className="relative flex items-center justify-between w-full">
+                    <h2 className="h1 text-center font-bold text-gray-1000 w-[450px]">
+                      {"인증번호 입력"}
+                    </h2>
+                    <button 
+                      onClick={resetModalState}
+                      className="flex items-center justify-center"
+                    >
+                      <svg width="36" height="36" viewBox="0 0 36 36" fill="none">
+                        <path d="M24 12L12 24M12 12L24 24" stroke="#666666" strokeWidth="2" strokeLinecap="round"/>
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <p className="text-[16px] text-gray-600 mt-2">
+                  입력하신 전화번호로 인증번호가 전송되었습니다.
+                </p>
+              </div>
+              <div className="space-y-[40px] mt-[32px]">
+                <div>
+                  <div className="relative">
+                    <Input 
+                      name="code" 
+                      type="text" 
+                      placeholder="인증번호를 입력해주세요."
+                      currentValue={verificationCode}
+                      handleInputChange={(e) => setVerificationCode(e.target.value)}
+                    />
+                    <span className="absolute right-[16px] top-1/2 -translate-y-1/2 text-primary-500 text-[16px] font-medium">
+                      {formatTime(timeLeft)}
+                    </span>
+                  </div>
+                  {verificationError && (
+                    <p
+                      className="mt-2 text-[16px] font-[500]"
+                      style={{ color: "#FF3D00" }}
+                    >
+                      {verificationError}
+                    </p>
+                  )}
+                </div>
+              </div>
+              <div className="mt-[40px]">
+                <Button onClick={handleVerification} content="인증하기" primary />
+              </div>
+            </div>
           </div>
-        </div>
-        <Button content="인증번호 전송" primary />
-      </form>
-    </div>
+        </div>,
+        document.body
+      )}
+    </>
   );
 }

--- a/src/components/login/organisms/IdentificationForm.tsx
+++ b/src/components/login/organisms/IdentificationForm.tsx
@@ -19,9 +19,10 @@ export default function IdentificationForm() {
           {"본인확인"}
         </h2>
         <div className="space-y-4">
-          <Input name="name" type="text" placeholder="이름" />
+          {/* <Input name="name" type="text" placeholder="이름" />
           <Input name="company" type="text" placeholder="기업명" />
-          <Input name="carrier" type="text" placeholder="통신사" />
+          <Input name="carrier" type="text" placeholder="통신사" /> */}
+          <Input name="email" type="email" placeholder="아이디(이메일)" />
           <Input name="phone" type="text" placeholder="핸드폰 번호" />
         </div>
         <Button content="인증번호 전송" primary />

--- a/src/components/login/organisms/IdentificationForm.tsx
+++ b/src/components/login/organisms/IdentificationForm.tsx
@@ -203,7 +203,10 @@ export default function IdentificationForm() {
     }
 
     if (response.ok) {
+      // 인증 상태와 함께 이메일, 전화번호도 저장
       sessionStorage.setItem('isVerified', 'true');
+      sessionStorage.setItem('verifiedEmail', formData.email);
+      sessionStorage.setItem('verifiedPhone', formData.phone);
       console.log("인증번호 인증 성공");
       replace("/login/reset");
     } else {

--- a/src/components/login/organisms/IdentificationForm.tsx
+++ b/src/components/login/organisms/IdentificationForm.tsx
@@ -203,10 +203,11 @@ export default function IdentificationForm() {
     }
 
     if (response.ok) {
+      sessionStorage.setItem('isVerified', 'true');
       console.log("인증번호 인증 성공");
-      replace("/login/reset"); // 바로 페이지 이동
+      replace("/login/reset");
     } else {
-      refresh(); // 실패 시 현재 페이지 새로고침
+      refresh();
     }
 };
 

--- a/src/components/login/organisms/IdentificationForm.tsx
+++ b/src/components/login/organisms/IdentificationForm.tsx
@@ -1,15 +1,105 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
 
-export default function IdentificationForm() {
-  const { replace } = useRouter();
+interface userIdentificationDto {
+  email: string;
+  phone: string;
+}
 
-  const handleIdentify = (e: React.FormEvent) => {
+export default function IdentificationForm() {
+  const { replace, refresh } = useRouter();
+  const [formData, setFormData] = useState<userIdentificationDto>({
+    email: "",
+    phone: "",
+  });
+
+  // 입력값 에러 상태 추가
+  const [errors, setErrors] = useState({
+    email: "",
+    phone: "",
+  });
+
+  // 본인 인증 에러 메시지를 위한 상태 추가
+  const [identificationError, setIdentificationError] = useState("");
+
+  // 모달 표시 상태 추가
+  const [showModal, setShowModal] = useState(false);
+  
+  // 입력값 유효성 검사 함수
+  const validateForm = () => {
+    let isValid = true;
+    const newErrors = {
+      email: "",
+      phone: "",
+    };
+
+    // 이메일 체크
+    if (!formData.email.trim()) {
+      newErrors.email = "이메일 주소를 입력해주세요.";
+      isValid = false;
+      setErrors(newErrors);
+      return isValid;  // 이메일이 비어있으면 바로 리턴
+    }
+
+    // 핸드폰 번호 체크
+    if (!formData.phone.trim()) {
+      newErrors.phone = "핸드폰 번호를 입력해주세요.";
+      isValid = false;
+    }
+
+    setErrors(newErrors);
+    return isValid;
+  };
+
+  const handleIdentify = async (e: React.FormEvent) => {
     e.preventDefault();
-    replace("/login/reset");
+
+      // 본인인증 시도 시 이전 에러 메시지 초기화
+      setIdentificationError("");
+
+     // 폼 데이터 확인을 위한 콘솔 로그
+     console.log("본인인증 시도:", {
+      이메일: formData.email,
+      전화번호: formData.phone,
+    });
+
+    // 폼 유효성 검사
+    if (!validateForm()) {
+      return;
+    }
+    
+    const response = await fetch(`/api/server/member/code`, {
+      method: "POST",
+      body: JSON.stringify({
+        email: formData.email,
+        phoneNumber: formData.phone,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    // API 응답 확인을 위한 콘솔 로그
+    console.log("API 응답 상태:", response.status);
+
+    // 로그인 실패 시 에러 처리
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      setIdentificationError("올바른 정보가 아닙니다.");
+      console.error("본인인증 실패:", errorMessage);
+      return;
+    }
+
+    if (response.ok) {
+      // replace("/login/reset");
+      console.log("본인인증 성공");
+    } else {
+      refresh(); // 실패 시 현재 페이지 새로고침
+    }
   };
 
   return (
@@ -22,8 +112,52 @@ export default function IdentificationForm() {
           {/* <Input name="name" type="text" placeholder="이름" />
           <Input name="company" type="text" placeholder="기업명" />
           <Input name="carrier" type="text" placeholder="통신사" /> */}
-          <Input name="email" type="email" placeholder="아이디(이메일)" />
-          <Input name="phone" type="text" placeholder="핸드폰 번호" />
+               <div>
+            <Input 
+              name="email" 
+              type="text" 
+              placeholder="아이디(이메일)"
+              currentValue={formData.email}
+              handleInputChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  email: e.target.value,
+                }))
+              }
+            />
+            {errors.email && (
+              <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
+                {errors.email}
+              </p>
+            )}
+          </div>
+          <div>
+            <Input 
+              name="phone" 
+              type="text" 
+              placeholder="핸드폰 번호"
+              currentValue={formData.phone}
+              handleInputChange={(e) =>
+                setFormData((prev) => ({
+                  ...prev,
+                  phone: e.target.value,
+                }))
+              }
+            />
+            {errors.phone && (
+              <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
+                {errors.phone}
+              </p>
+            )}
+              {/* 본인인증 에러 메시지를 전화번호 필드 아래에 표시 */}
+              {identificationError && (
+              <p
+                className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}
+              >
+                {identificationError}
+              </p>
+            )}
+          </div>
         </div>
         <Button content="인증번호 전송" primary />
       </form>

--- a/src/components/login/organisms/LoginForm.tsx
+++ b/src/components/login/organisms/LoginForm.tsx
@@ -99,7 +99,7 @@ export default function LoginForm() {
     // 로그인 실패 시 에러 처리
     if (!response.ok) {
       const errorMessage = await response.text();
-      setLoginError(errorMessage);
+      setLoginError("올바른 정보가 아닙니다.");
       console.error("로그인 실패:", errorMessage);
       return;
     }

--- a/src/components/login/organisms/LoginForm.tsx
+++ b/src/components/login/organisms/LoginForm.tsx
@@ -45,12 +45,16 @@ export default function LoginForm() {
       id: "",
       password: "",
     };
-
+   
+    // 아이디 체크를 먼저 수행
     if (!formData.id.trim()) {
       newErrors.id = "필수 입력사항입니다.";
       isValid = false;
+      setErrors(newErrors);
+      return isValid;  // 아이디가 비어있으면 바로 리턴
     }
 
+    // 아이디가 있을 때만 비밀번호 체크
     if (!formData.password.trim()) {
       newErrors.password = "필수 입력사항입니다.";
       isValid = false;

--- a/src/components/login/organisms/ResetPasswordForm.tsx
+++ b/src/components/login/organisms/ResetPasswordForm.tsx
@@ -13,7 +13,10 @@ export default function ResetPasswordForm() {
 
   useEffect(() => {
     const isVerified = sessionStorage.getItem('isVerified');
-    if (!isVerified && !alertShown.current) {
+    const verifiedEmail = sessionStorage.getItem('verifiedEmail');
+    const verifiedPhone = sessionStorage.getItem('verifiedPhone');
+
+    if ((!isVerified || !verifiedEmail || !verifiedPhone) && !alertShown.current) {
       alertShown.current = true;
       alert("본인인증이 필요한 페이지입니다.");
       replace(`${LOGIN_ENDPOINT}`);

--- a/src/components/login/organisms/ResetPasswordForm.tsx
+++ b/src/components/login/organisms/ResetPasswordForm.tsx
@@ -6,10 +6,30 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState, useRef } from "react";
 import { LOGIN_ENDPOINT } from "@/lib/constants";
 
+interface ResetPasswordDto {
+  email: string;
+  phone: string;
+  newPassword: string;
+}
+
 export default function ResetPasswordForm() {
   const { replace, refresh } = useRouter();
-  const [isAuthorized, setIsAuthorized] = useState(false);
   const alertShown = useRef(false);
+  // 초기 상태는 빈 값으로 설정
+  const [formData, setFormData] = useState<ResetPasswordDto>({
+    email: '',
+    phone: '',
+    newPassword: ''
+  });
+
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  // 입력값 에러 상태 추가
+  const [errors, setErrors] = useState({
+    newPassword: '',
+    confirmPassword: ''
+  });
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [resetPasswordError, setResetPasswordError] = useState(""); // 비밀번호 재설정 에러 메시지를 위한 상태 추가
 
   useEffect(() => {
     const isVerified = sessionStorage.getItem('isVerified');
@@ -22,11 +42,130 @@ export default function ResetPasswordForm() {
       replace(`${LOGIN_ENDPOINT}`);
       return;
     }
-    setIsAuthorized(true);
-  }, []);
 
-  const handleResetPassword = (e: React.FormEvent) => {
+    // 세션 스토리지에서 가져온 값으로 폼 데이터 업데이트
+    if (verifiedEmail && verifiedPhone) {
+      setFormData({
+        email: verifiedEmail,
+        phone: verifiedPhone,
+        newPassword: ''
+      });
+    } else {
+      // 세션 스토리지 값이 없는 경우 처리
+      console.error('세션 스토리지에 필요한 값이 없습니다.');
+      if (!alertShown.current) {
+        alertShown.current = true;
+        alert("세션 정보가 유효하지 않습니다. 다시 시도해주세요.");
+        replace(`${LOGIN_ENDPOINT}`);
+      }
+      return;
+    }
+    
+    setIsAuthorized(true);
+  }, [replace]);
+
+  // 입력값 유효성 검사 함수
+  const validateForm = () => {
+    const newErrors = {
+      newPassword: "",
+      confirmPassword: ""
+    };
+
+    /**
+     * 비밀번호 유효성 검사를 위한 정규식
+     * 다음 조건을 충족해야 함:
+     * 1. 최소 8자, 최대 20자
+     * 2. 최소 하나의 영문자(대문자 또는 소문자) 포함
+     * 3. 최소 하나의 숫자 포함
+     * 4. 최소 하나의 특수 문자 포함 (!@#$%^&*(),.?":{}|<> 중 하나)
+     */
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*(),.?":{}|<>]).{8,20}$/;
+    
+    // 1. 새 비밀번호 정규식 체크
+    if (!passwordRegex.test(formData.newPassword)) {
+      newErrors.newPassword = "영어, 숫자, 특수문자를 조합하여 8자 이상 20자 이하로 입력해주세요.";
+      setErrors(newErrors);
+      return false;
+    }
+
+    // 2. 새 비밀번호 확인 정규식 체크
+    if (!passwordRegex.test(confirmPassword)) {
+      newErrors.confirmPassword = "영어, 숫자, 특수문자를 조합하여 8자 이상 20자 이하로 입력해주세요.";
+      setErrors(newErrors);
+      return false;
+    }
+
+    // 3. 두 비밀번호 일치 여부 체크
+    if (formData.newPassword !== confirmPassword) {
+      newErrors.confirmPassword = "입력하신 비밀번호와 일치하지 않아요.";
+      setErrors(newErrors);
+      return false;
+    }
+
+    // 모든 검증을 통과한 경우
+    setErrors(newErrors); // 에러 초기화
+    return true;
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    if (name === 'rePassword') {
+      setConfirmPassword(value);
+    } else if (name === 'password') {
+      setFormData({
+        ...formData,
+        newPassword: value
+      });
+    }
+  }
+
+  const handleResetPassword = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    // 비밀번호 재설정 시도 시 이전 에러 메시지 초기화
+    setResetPasswordError("");
+
+    // 폼 데이터 확인을 위한 콘솔 로그
+    console.log("비밀번호 재설정 시도:", {
+        이메일: formData.email,
+        전화번호: formData.phone,
+        newPassword: formData.newPassword,
+        confirmPassword: confirmPassword,
+     });
+
+    // 폼 유효성 검사
+    if (!validateForm()) {
+      return;
+    }
+
+    const response = await fetch(`/api/server/member/password`, {
+      method: "POST",
+      body: JSON.stringify({
+        email: formData.email,
+        phoneNumber: formData.phone,
+        password: formData.newPassword
+      }),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+
+    // API 응답 확인을 위한 콘솔 로그
+    console.log("API 응답 상태:", response.status);
+
+    if (!response.ok) {
+      const errorMessage = await response.text();
+      setResetPasswordError("비밀번호 재설정에 실패했습니다.");
+      console.error("비밀번호 재설정 실패:", errorMessage);
+      return;
+    }
+
+    if (response.ok) {
+      alert("비밀번호 재설정이 완료되었습니다.");
+      replace(`${LOGIN_ENDPOINT}`);
+    } else {
+      refresh();
+    }
   };
 
   if (!isAuthorized) return null;
@@ -45,12 +184,26 @@ export default function ResetPasswordForm() {
             name="password"
             type="password"
             placeholder="새 비밀번호 입력(8~20자)"
+            value={formData.newPassword}
+            onChange={handleInputChange}
           />
+          {errors.newPassword && (
+            <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
+              {errors.newPassword}
+            </p>
+          )}
           <Input
             name="rePassword"
             type="password"
             placeholder="새 비밀번호 재입력"
+            value={confirmPassword}
+            onChange={handleInputChange}
           />
+          {errors.confirmPassword && (
+            <p className="mt-2 text-[16px] font-[500]" style={{ color: "#FF3D00" }}>
+              {errors.confirmPassword}
+            </p>
+          )}
         </div>
         <Button content="확인" primary />
       </form>

--- a/src/components/login/organisms/ResetPasswordForm.tsx
+++ b/src/components/login/organisms/ResetPasswordForm.tsx
@@ -2,11 +2,31 @@
 
 import Button from "@/components/common/Button";
 import Input from "@/components/common/Input";
+import { useRouter } from "next/navigation";
+import { useEffect, useState, useRef } from "react";
+import { LOGIN_ENDPOINT } from "@/lib/constants";
 
 export default function ResetPasswordForm() {
+  const { replace, refresh } = useRouter();
+  const [isAuthorized, setIsAuthorized] = useState(false);
+  const alertShown = useRef(false);
+
+  useEffect(() => {
+    const isVerified = sessionStorage.getItem('isVerified');
+    if (!isVerified && !alertShown.current) {
+      alertShown.current = true;
+      alert("본인인증이 필요한 페이지입니다.");
+      replace(`${LOGIN_ENDPOINT}`);
+      return;
+    }
+    setIsAuthorized(true);
+  }, []);
+
   const handleResetPassword = (e: React.FormEvent) => {
     e.preventDefault();
   };
+
+  if (!isAuthorized) return null;
 
   return (
     <div className="p-8 rounded-4xl shadow bg-gray-0">


### PR DESCRIPTION
### DESCRIPTION
본 PR에서는 본인 확인(인증) 및 비밀번호 재설정 기능을 구현하고, 관련된 UI 및 API 연동을 추가했습니다.

### CHANGES
🔹 본인 확인 폼 및 API 연동
1. 본인 확인(인증) 폼 추가
- 이메일, 핸드폰 번호 입력 필드 구현
- 입력값 유효성 검사 (validateForm) 추가
- 오류 메시지 상태 관리 (errors, setIdentificationError)
2. 본인 인증 API 연동
- /api/server/member/code로 인증 요청 (fetch 활용)
- API 응답 상태 확인 및 에러 메시지 표시
- 인증 실패 시 적절한 메시지 제공
3. UI 개선
- 오류 메시지 UI 적절한 위치 배치
- console.log 정리 및 디버깅 개선

🔹 비밀번호 재설정 페이지 접근 제어
1. 본인 인증 없이 직접 접근 차단
- sessionStorage를 활용한 인증 상태 관리 (isVerified)
- 본인 인증이 완료되지 않은 경우 로그인 페이지로 리다이렉트
2. 인증 정보 저장 및 검증 강화
- sessionStorage에 이메일, 전화번호 저장하여 API 요청 시 활용
- 필수 인증 데이터(isVerified, verifiedEmail, verifiedPhone) 검증 후 접근 제어

🔹 비밀번호 재설정 인증번호 입력 모달
1. 인증번호 입력 모달 추가
- 3분 타이머 기능 구현
- 인증번호 입력 필드 및 유효성 검사 추가
- 타이머 만료 시 에러 메시지 표시
- 모달 상태 초기화 기능 추가
2. UX 개선
- 인증 성공 시 자동으로 비밀번호 재설정 페이지 이동

🔹 기타 개선
1. 로그인 입력값 검증 로직 수정
- 아이디 입력 후에만 비밀번호 검증 수행
- 비어 있는 경우 즉시 반환 및 에러 메시지 추가
2. 로그인 실패 시 서버 에러 메시지 직접 노출하지 않고 사용자 친화적인 "올바른 정보가 아닙니다."로 변경
3. UI 및 UX 최적화 (불필요한 렌더링 방지, 중복 alert 방지)

✅ 해결된 문제
- 본인 인증 및 비밀번호 재설정 API 연동
- 인증되지 않은 사용자의 접근 제한
- 입력값 검증 강화 및 사용자 친화적인 메시지 제공
- 불필요한 렌더링 방지 및 UX 개선
- 비밀번호 변경 성공 시 로그인 페이지로 자동 이동

Closes #137 
