### PR TITLE
fix/#141-password-kakao

### DIFF
--- a/src/components/header/molecules/CustomerCenter.tsx
+++ b/src/components/header/molecules/CustomerCenter.tsx
@@ -22,7 +22,15 @@ export default function CustomerCenter() {
             </div>
           </div>
           <div className="text-center">
-            <button className="mx-auto" onClick={() => closeModal()}>
+            <button 
+              className="mx-auto" 
+              onClick={() => {
+                // 카카오톡 채널 링크로 이동
+                window.open('https://open.kakao.com/o/s1t61zah', '_blank');
+                // 모달 닫기
+                closeModal();
+              }}
+            >
               <Image
                 src={KakaoButton}
                 alt="카카오톡"

--- a/src/components/login/organisms/ResetPasswordForm.tsx
+++ b/src/components/login/organisms/ResetPasswordForm.tsx
@@ -77,20 +77,19 @@ export default function ResetPasswordForm() {
      * 1. 최소 8자, 최대 20자
      * 2. 최소 하나의 영문자(대문자 또는 소문자) 포함
      * 3. 최소 하나의 숫자 포함
-     * 4. 최소 하나의 특수 문자 포함 (!@#$%^&*(),.?":{}|<> 중 하나)
      */
-    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*(),.?":{}|<>]).{8,20}$/;
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,20}$/;
     
     // 1. 새 비밀번호 정규식 체크
     if (!passwordRegex.test(formData.newPassword)) {
-      newErrors.newPassword = "영어, 숫자, 특수문자를 조합하여 8자 이상 20자 이하로 입력해주세요.";
+      newErrors.newPassword = "영어, 숫자를 조합하여 8자 이상 20자 이하로 입력해주세요.";
       setErrors(newErrors);
       return false;
     }
 
     // 2. 새 비밀번호 확인 정규식 체크
     if (!passwordRegex.test(confirmPassword)) {
-      newErrors.confirmPassword = "영어, 숫자, 특수문자를 조합하여 8자 이상 20자 이하로 입력해주세요.";
+      newErrors.confirmPassword = "영어, 숫자를 조합하여 8자 이상 20자 이하로 입력해주세요.";
       setErrors(newErrors);
       return false;
     }


### PR DESCRIPTION
### DESCRIPTION
비밀번호 정책을 변경하고, 고객센터에 카카오톡 채널 연결 기능을 추가했습니다.

### CHANGES
1. 비밀번호 정책 변경

- 비밀번호 정규식에서 특수 문자 요구 조건 제거
- 비밀번호 검증 시 특수 문자 관련 메시지 제거

2. 고객센터 카카오톡 채널 연결 기능 추가

- 버튼 클릭 시 카카오톡 채널 링크가 새 창에서 열리도록 수정
- 링크 이동 후 모달 자동 닫기 기능 추가

Closes #141 
