### PR TITLE
fix/#143-dashboard-api-ui

### DIFF
--- a/src/components/dashboard/club/main/molecules/Overview.tsx
+++ b/src/components/dashboard/club/main/molecules/Overview.tsx
@@ -68,7 +68,6 @@ export default async function DashboardOverview() {
   // console.log(clubJoinRequest);
 
   const [dashboardNotifications, clubName] = await Promise.all([getDashboardNotifications(), getClubName()]);
-  console.log(dashboardNotifications);
 
   // API 응답에서 안전하게 데이터 추출
   const newJoinRequests = dashboardNotifications?.data?.newJoinRequests || 0;

--- a/src/components/dashboard/club/main/molecules/Overview.tsx
+++ b/src/components/dashboard/club/main/molecules/Overview.tsx
@@ -1,25 +1,62 @@
 import Link from "next/link";
 import { getData } from "@/api/action";
 import type { NotificationData } from "@/api/types/club/notification";
-import { CLUB_DASHBOARD_ENDPOINT } from "@/lib/constants";
+import { LOGIN_ENDPOINT, CLUB_DASHBOARD_ENDPOINT } from "@/lib/constants";
+import { getAccessToken, getClubId, getClubName } from "@/lib/cookies";
 
-import { getAccessToken, getClubId } from "@/lib/cookies";
 
 // 개발 중간에 엔드 포인트가 변경되어 getData 사용 시 모든 참조를 찾아서 일일이 수정해야 합니다. 권장 x...
-const getClubJoinRequest = async () => {
-  const [clubId, token] = await Promise.all([getClubId(), getAccessToken()]);
+// const getClubJoinRequest = async () => {
+//   const [clubId, token] = await Promise.all([getClubId(), getAccessToken()]);
 
-  const res = await fetch(
-    `${process.env.NEXT_PUBLIC_SERVER_URL}/v1/executive/club/${clubId}/count/pending`,
-    {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      cache: "force-cache",
+//   const res = await fetch(
+//     `${process.env.NEXT_PUBLIC_SERVER_URL}/v1/executive/club/${clubId}/count/pending`,
+//     {
+//       headers: {
+//         Authorization: `Bearer ${token}`,
+//       },
+//       cache: "force-cache",
+//     }
+//   );
+
+//   return res.json();
+// };
+
+const getDashboardNotifications = async () => {
+  try {
+    const [clubId, token] = await Promise.all([getClubId(), getAccessToken()]);
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_SERVER_URL}v1/executive/club/${clubId}/dashboard/notifications`,
+      {
+        method: "GET",
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        cache: "force-cache"
+      });
+    
+    // API 응답 확인을 위한 콘솔 로그
+    console.log("API 응답 상태:", res.status);
+
+    if (res.status === 401) {
+      alert("인증이 필요한 서비스입니다. 다시 로그인해 주세요.");
+      window.location.href = LOGIN_ENDPOINT;
+      return;
     }
-  );
 
-  return res.json();
+    // 다른 에러 처리
+    if (!res.ok) {
+      const errorData = await res.json();
+      console.error('API 응답 에러:', errorData);
+      return;
+    }
+    
+    return res.json();
+  } catch (error) {
+    console.error('알림 카드 목록 조회 에러:', error);
+  }
 };
 
 export default async function DashboardOverview() {
@@ -27,12 +64,20 @@ export default async function DashboardOverview() {
   // const data: NotificationData = res.data;
 
   // 이후 주무부서 공지사항, 최근 omo 공지사항 연동해야함
-  const [clubJoinRequest] = await Promise.all([getClubJoinRequest()]);
-  console.log(clubJoinRequest);
+  // const [clubJoinRequest] = await Promise.all([getClubJoinRequest()]);
+  // console.log(clubJoinRequest);
+
+  const [dashboardNotifications, clubName] = await Promise.all([getDashboardNotifications(), getClubName()]);
+  console.log(dashboardNotifications);
+
+  // API 응답에서 안전하게 데이터 추출
+  const newJoinRequests = dashboardNotifications?.data?.newJoinRequests || 0;
+  const recentManagerNotices = dashboardNotifications?.data?.recentManagerNotices || 0;
+  const recentOmoNotices = dashboardNotifications?.data?.recentOmoNotices || 0;
 
   return (
     <div className="col-span-4 flex flex-col gap-6 h-fit p-8 rounded-xl bg-gray-800 select-none">
-      <h3 className="h1 font-bold text-gray-0">{"동호회 이름 주요 알림"}</h3>
+      <h3 className="h1 font-bold text-gray-0">{`${clubName || '동호회'} 주요 알림`}</h3>
       <div className="flex gap-8 truncate">
         <div className="flex-1 flex flex-col gap-4 py-3 px-2">
           <span className="h4 font-medium text-gray-400">
@@ -40,7 +85,7 @@ export default async function DashboardOverview() {
           </span>
           <Link href={`${CLUB_DASHBOARD_ENDPOINT}/manage/member?filter=new`}>
             <span className="h1 font-extrabold text-brand-orange underline underline-offset-4 decoration-gray-800 hover:decoration-brand-orange transition duration-300">
-              {`${clubJoinRequest.data || 0}건`}
+              {`${newJoinRequests}건`}
             </span>
           </Link>
         </div>
@@ -63,7 +108,7 @@ export default async function DashboardOverview() {
           </span>
           <Link href={`${CLUB_DASHBOARD_ENDPOINT}/announcement?filter=company`}>
             <span className="h1 font-extrabold text-gray-0 underline underline-offset-4 decoration-gray-800 hover:decoration-gray-0 transition duration-300">
-              {`0건`}
+              {`${recentManagerNotices}건`}
             </span>
           </Link>
         </div>
@@ -74,7 +119,7 @@ export default async function DashboardOverview() {
           </span>
           <Link href={`${CLUB_DASHBOARD_ENDPOINT}/announcement?filter=omo`}>
             <span className="h1 font-extrabold text-gray-0 underline underline-offset-4 decoration-gray-800 hover:decoration-gray-0 transition duration-300">
-              {`0건`}
+              {`${recentOmoNotices}건`}
             </span>
           </Link>
         </div>

--- a/src/components/dashboard/club/main/molecules/Ranking.tsx
+++ b/src/components/dashboard/club/main/molecules/Ranking.tsx
@@ -1,14 +1,70 @@
 import { getData } from "@/api/action";
 import type { RankingData } from "@/api/types/club/ranking";
 import { cn } from "@/lib/utils";
+import { getAccessToken, getClubId, getClubName } from "@/lib/cookies";
 import RankingCursor from "@/components/dashboard/club/main/atoms/RankingCursor";
+import { LOGIN_ENDPOINT } from "@/lib/constants";
+import type { IResponse } from "@/api/types";
+
+// 랭킹 데이터 조회 API 호출 함수
+const getDashboardRankings = async () => {
+  try {
+    const [clubId, token] = await Promise.all([getClubId(), getAccessToken()]);
+    const url = `${process.env.NEXT_PUBLIC_SERVER_URL}v1/executive/club/${clubId}/dashboard/rankings`;
+    
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Authorization": `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      cache: "force-cache"
+    });
+
+    // API 응답 확인을 위한 콘솔 로그
+    console.log("API 응답 상태:", response.status);
+
+    if (response.status === 401) {
+      alert("인증이 필요한 서비스입니다. 다시 로그인해 주세요.");
+      window.location.href = LOGIN_ENDPOINT;
+      return;
+    }
+    
+    // 정상 응답 처리
+    const res: IResponse = await response.json();
+    const data = res.data;
+    console.log("응답 데이터:", data);
+    return data;
+  } catch (error) {
+    console.error('랭킹 데이터 조회 오류:', error);
+    return { data: null };
+  }
+};
 
 export default async function DashboardRanking() {
-  const res = await getData("v2/club/web/ranking/", true);
-  const data: RankingData = res.data;
+  // const res = await getData("v2/club/web/ranking/", true);
+  // const data: RankingData = res.data;
 
-  const myClubRank = data.myClubRanking || 0;
-  const maxHeight = data.clubRankingDetails[0].clubMember;
+  // 랭킹 데이터 조회
+  const rankingData = await getDashboardRankings();
+
+  // 안전하게 데이터 추출 및 기본값 설정
+  const totalClubCount = rankingData.totalClubCount || 0;
+
+  // 현재 클럽 ID 가져오기
+  const currentClubId = await getClubId();
+
+  // 내 클럽 순위 찾기
+  let myClubRank = 0;
+  const myClubDetail = rankingData.rankings.find(
+    (club: { clubId: string }) => club.clubId.toString() === currentClubId
+  );
+  
+  if (myClubDetail) {
+    myClubRank = myClubDetail.rank;
+  }
+  
+  const maxHeight = rankingData.rankings[0].memberCount;
 
   return (
     <div className="flex-1 flex flex-col justify-between h-[473px] p-8 rounded-xl bg-gray-0">
@@ -16,76 +72,76 @@ export default async function DashboardRanking() {
       <div className="space-y-2">
         <h3 className="h1 font-bold text-brand-black">{"사내동호회 순위"}</h3>
         <div className="flex flex-col">
-          <span className="body-2 font-bold text-gray-500">{`총 ${data.totalClubCount || 0}개 중`}</span>
-          <span className="h1 font-extrabold text-gray-800">{`${myClubRank}위`}</span>
+          <span className="body-2 font-bold text-gray-500">{`총 ${totalClubCount || 0}개 중`}</span>
+          <span className="h1 font-extrabold text-gray-800">{`${myClubRank || '-'}위`}</span>
         </div>
       </div>
-      {data ? (
+      {rankingData ? (
         <div className="flex items-end gap-2.5">
           {myClubRank > 6 ? (
             <>
-              {data.clubRankingDetails.slice(0, 5).map((club) => (
+              {rankingData.rankings.slice(0, 5).map((club: { clubId: string; clubName: string; memberCount: number; rank: number }) => (
                 <div
                   key={club.clubId}
                   id={club.clubName}
                   className="space-y-2 w-[46px] ranking-other-club cursor-pointer"
                 >
-                  <div className="w-full text-center body-2 font-medium text-gray-500">{`${club.clubMember}명`}</div>
+                  <div className="w-full text-center body-2 font-medium text-gray-500">{`${club.memberCount}명`}</div>
                   <div className="relative group">
                     <div className="opacity-0 group-hover:opacity-100 absolute -top-2.5 left-[15px] w-4 h-4 rounded-full border-[3px] border-gray-0 bg-brand-orange shadow-xs transition-opacity duration-200" />
                     <div
                       style={{
-                        height: `${(club.clubMember / maxHeight) * 200}px`,
+                        height: `${(club.memberCount / maxHeight) * 200}px`,
                       }}
                       className="w-full rounded-lg bg-gray-200"
                     />
                   </div>
                   <div className="w-full text-center h4 font-bold text-gray-800">
-                    {club.ranking}
+                    {club.rank}
                   </div>
                 </div>
               ))}
-              {data.clubRankingDetails
+              {rankingData.rankings
                 .slice(myClubRank - 1, myClubRank)
-                .map((club) => (
+                .map((club: { clubId: string; clubName: string; memberCount: number; rank: number }) => (
                   <div key={club.clubId} className="space-y-2 w-[46px]">
-                    <div className="w-full text-center body-2 font-medium text-gray-500">{`${club.clubMember}명`}</div>
+                    <div className="w-full text-center body-2 font-medium text-gray-500">{`${club.memberCount}명`}</div>
                     <div
                       style={{
-                        height: `${(club.clubMember / maxHeight) * 200}px`,
+                        height: `${(club.memberCount / maxHeight) * 200}px`,
                       }}
                       className="w-full rounded-lg bg-brand-orange"
                     />
                     <div className="w-full text-center h4 font-bold text-gray-0 rounded-full bg-gray-800">
-                      {club.ranking}
+                      {club.rank}
                     </div>
                   </div>
                 ))}
             </>
           ) : (
-            data.clubRankingDetails.slice(0, 6).map((club) => (
+            rankingData.rankings.slice(0, 6).map((club: { clubId: string; clubName: string; memberCount: number; rank: number }) => (
               <div
                 key={club.clubId}
                 id={club.clubName}
                 className={cn(
                   "space-y-2 w-[46px]",
-                  club.ranking === myClubRank
+                  club.rank === myClubRank
                     ? ""
                     : "ranking-other-club cursor-pointer"
                 )}
               >
-                <div className="w-full text-center body-2 font-medium text-gray-500">{`${club.clubMember}명`}</div>
+                <div className="w-full text-center body-2 font-medium text-gray-500">{`${club.memberCount}명`}</div>
                 <div className="relative group">
-                  {club.ranking !== myClubRank && (
+                  {club.rank !== myClubRank && (
                     <div className="opacity-0 group-hover:opacity-100 absolute -top-2.5 left-[15px] w-4 h-4 rounded-full border-[3px] border-gray-0 bg-brand-orange shadow-xs transition-opacity duration-200" />
                   )}
                   <div
                     style={{
-                      height: `${(club.clubMember / maxHeight) * 200}px`,
+                      height: `${(club.memberCount / maxHeight) * 200}px`,
                     }}
                     className={cn(
                       "w-full rounded-lg",
-                      club.ranking === myClubRank
+                      club.rank === myClubRank
                         ? "bg-brand-orange"
                         : "bg-gray-200"
                     )}
@@ -94,12 +150,12 @@ export default async function DashboardRanking() {
                 <div
                   className={cn(
                     "w-full text-center h4 font-bold",
-                    club.ranking === myClubRank
+                    club.rank === myClubRank
                       ? "text-gray-0 rounded-full bg-gray-800"
                       : "text-gray-800"
                   )}
                 >
-                  {club.ranking}
+                  {club.rank}
                 </div>
               </div>
             ))
@@ -113,3 +169,4 @@ export default async function DashboardRanking() {
     </div>
   );
 }
+

--- a/src/components/login/organisms/ClubSelectForm.tsx
+++ b/src/components/login/organisms/ClubSelectForm.tsx
@@ -7,10 +7,12 @@ import type { LoginClubData, LoginClubDTO } from "@/api/types/member/login";
 import { getAccessToken, saveClubId, saveClubName } from "@/lib/cookies";
 import { cn } from "@/lib/utils";
 import Button from "@/components/common/Button";
-import { LOGIN_ENDPOINT } from "@/lib/constants";
+import { LOGIN_ENDPOINT, CLUB_DASHBOARD_ENDPOINT } from "@/lib/constants";
 
 export default function ClubSelectForm() {
-  const { refresh } = useRouter();
+  // const { refresh } = useRouter();
+  const router = useRouter();
+
   const [clubOptions, setClubOptions] = useState<LoginClubDTO[]>();
   const [selectedClub, setSelectedClub] = useState<LoginClubDTO>();
   
@@ -90,7 +92,10 @@ export default function ClubSelectForm() {
     await saveClubName(selectedClub.clubName);
     console.log('클럽 이름 저장 완료:', selectedClub.clubName);
 
-    refresh();
+    // 🚀 100ms 지연 후 refresh() 실행하여 쿠키 반영 대기
+    setTimeout(() => {
+      router.push(CLUB_DASHBOARD_ENDPOINT);
+    }, 100);
   };
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -14,9 +14,6 @@ export function middleware(req: NextRequest) {
   const clubId = cookies().get("clubId");
   
   console.log("🔍 미들웨어 실행됨");
-  console.log("🔹 type:", type?.value);
-  console.log("🔹 clubId:", clubId?.value)
-  console.log("🔹 req.nextUrl.pathname:", req.nextUrl.pathname);
 
   if (req.nextUrl.pathname === "/") {
     if (refreshToken) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -12,6 +12,11 @@ export function middleware(req: NextRequest) {
   const refreshToken = cookies().get("refreshToken");
   const type = cookies().get("type");
   const clubId = cookies().get("clubId");
+  
+  console.log("🔍 미들웨어 실행됨");
+  console.log("🔹 type:", type?.value);
+  console.log("🔹 clubId:", clubId?.value)
+  console.log("🔹 req.nextUrl.pathname:", req.nextUrl.pathname);
 
   if (req.nextUrl.pathname === "/") {
     if (refreshToken) {


### PR DESCRIPTION
### DESCRIPTION
이번 PR에서는 다음과 같은 주요 변경사항을 포함합니다:
- API 요청 시 fetch를 사용하여 데이터 가져오는 방식 개선
- getData 사용을 줄이고, API 호출 시 Promise.all() 활용
- ClubSelectForm에서 refresh()를 router.push()로 변경하여 리다이렉션 개선
- 미들웨어에서 refreshToken 체크 로직 수정
- Ranking.tsx의 API 요청 방식 변경 및 안전한 데이터 처리 추가
- Overview.tsx에서 console.log() 제거 및 응답 상태 체크 로직 개선

### CHANGES

1. API 호출 방식 개선
- fetch 기반으로 API 요청을 변경하고, force-cache 설정 추가
- API 응답 에러 핸들링 로직 추가 (401 처리 포함)

2. UI 반영 최적화
- ClubSelectForm에서 refresh() 제거하고 router.push()를 이용한 리다이렉션 적용
- setTimeout()을 사용하여 쿠키 반영을 기다린 후 이동하도록 개선

3. 데이터 구조 변경 반영
- Ranking.tsx에서 기존 data 참조 대신 rankingData를 활용하여 UI 업데이트
- Overview.tsx에서 dashboardNotifications 구조 변경 및 안전한 데이터 추출 (?. 연산자 활용)

4. 불필요한 로그 삭제
- console.log()를 제거하여 클린 코드 유지

Closes #143 
