### PR TITLE
fix/#145-upcoming-club-events

### DIFF
--- a/src/api/action.ts
+++ b/src/api/action.ts
@@ -7,7 +7,8 @@ export const getData = async (endpoint: string, useClubId?: boolean) => {
   const clubId = await getClubId();
   const token = await getAccessToken();
 
-  const url = `${process.env.NEXT_PUBLIC_SERVER_URL}${endpoint}${useClubId ? clubId : ""}`;
+  // const url = `${process.env.NEXT_PUBLIC_SERVER_URL}${endpoint}${useClubId ? clubId : ""}`;
+  const url = `${process.env.NEXT_PUBLIC_SERVER_URL}${endpoint.replace("{clubId}", `${clubId}`)}`;
 
   const response = await fetch(url, {
     headers: {

--- a/src/components/dashboard/club/main/molecules/Overview.tsx
+++ b/src/components/dashboard/club/main/molecules/Overview.tsx
@@ -36,15 +36,6 @@ const getDashboardNotifications = async () => {
         },
         cache: "force-cache"
       });
-    
-    // API 응답 확인을 위한 콘솔 로그
-    console.log("API 응답 상태:", res.status);
-
-    if (res.status === 401) {
-      alert("인증이 필요한 서비스입니다. 다시 로그인해 주세요.");
-      window.location.href = LOGIN_ENDPOINT;
-      return;
-    }
 
     // 다른 에러 처리
     if (!res.ok) {

--- a/src/components/dashboard/club/main/molecules/Ranking.tsx
+++ b/src/components/dashboard/club/main/molecules/Ranking.tsx
@@ -20,20 +20,10 @@ const getDashboardRankings = async () => {
       },
       cache: "force-cache"
     });
-
-    // API 응답 확인을 위한 콘솔 로그
-    console.log("API 응답 상태:", response.status);
-
-    if (response.status === 401) {
-      alert("인증이 필요한 서비스입니다. 다시 로그인해 주세요.");
-      window.location.href = LOGIN_ENDPOINT;
-      return;
-    }
     
     // 정상 응답 처리
     const res: IResponse = await response.json();
     const data = res.data;
-    console.log("응답 데이터:", data);
     return data;
   } catch (error) {
     console.error('랭킹 데이터 조회 오류:', error);

--- a/src/components/dashboard/club/main/molecules/Schedule.tsx
+++ b/src/components/dashboard/club/main/molecules/Schedule.tsx
@@ -1,10 +1,33 @@
 import { getData } from "@/api/action";
 import type { UpcomingActivityData } from "@/api/types/club/upcoming/activity";
+import { LOGIN_ENDPOINT } from "@/lib/constants";
 import { cn, formatDate } from "@/lib/utils";
 
+
+// 이 파일에서만 사용할 API 응답 아이템 타입 정의
+interface ApiActivityItem {
+  id: number;
+  createdDate: string;
+  title?: string;
+  currentMember: number;
+  detail: string;
+}
+
 export default async function DashboardSchedule() {
-  const res = await getData("v2/club/web/upcoming/activity/", true);
-  const data: UpcomingActivityData = res.data;
+  const res = await getData("v1/executive/club/{clubId}/dashboard/schedules/upcoming", true);
+  const apiResponse = res.data as ApiActivityItem[]; // API 응답 (배열)
+  
+  // API 응답을 인터페이스에 맞게 변환
+  const data: UpcomingActivityData = {
+    count: apiResponse.length,
+    contents: apiResponse.map((item: ApiActivityItem, index: number) => ({
+      date: item.createdDate,
+      order: index + 1,
+      activityName: item.title || `활동 ${item.id}`,
+      memberCount: item.currentMember,
+      detail: item.detail
+  }))
+};
 
   return (
     <div className="space-y-6 p-8 rounded-xl bg-gray-0">
@@ -52,7 +75,7 @@ export default async function DashboardSchedule() {
                   )}
                 >
                   {i === 0
-                    ? formatDate(new Date(data))
+                    ? data
                     : i === 3
                       ? `${data}명`
                       : data}


### PR DESCRIPTION
### DESCRIPTION

- 프론트엔드에서 다가오는 동호회 일정을 조회할 수 있도록 새로운 API에 연동하고,  
기존 콘솔 로그 및 인증 처리, clubId 동적 치환 방식 등 전반적인 개선 작업을 진행했습니다.

### CHANGES

- v1/executive/club/{clubId}/dashboard/schedules/upcoming API로 연동 변경응답 타입 ApiActivityItem 정의 및 UpcomingActivityData에 매핑 처리 추가
- 날짜 포맷 변경 대응 (formatDate(new Date()) → 단순 문자열 출력)
- 콘솔 로그 및 401 인증 리다이렉트 로직 제거


### SCREENSHOTS
![image](https://github.com/user-attachments/assets/aa27be0f-fdb8-4ecb-84fe-01ba50f14408)


Closes #145 
