### PR TITLE
feat: 관리 중인 동호회 선택 화면 개선

### DIFF
--- a/src/components/login/organisms/ClubSelectForm.tsx
+++ b/src/components/login/organisms/ClubSelectForm.tsx
@@ -16,6 +16,8 @@ export default function ClubSelectForm() {
   const [clubOptions, setClubOptions] = useState<LoginClubDTO[]>();
   const [selectedClub, setSelectedClub] = useState<LoginClubDTO>();
   
+  let alertShown = false;
+  
   const getClubOptions = async () => {
     const token = await getAccessToken();
 
@@ -29,36 +31,31 @@ export default function ClubSelectForm() {
       });
       
       // API 응답 확인을 위한 콘솔 로그
-      console.log("API 응답 상태:", response.status);
+      // console.log("API 응답 상태:", response.status);
 
-      // 401 인증 에러 처리
-      if (response.status === 401) {
-        // sessionStorage에 체크값을 저장하여 중복 alert 방지
-        if (!sessionStorage.getItem('auth_alert')) {
-          sessionStorage.setItem('auth_alert', 'true');
-          alert('인증이 필요한 서비스입니다. 다시 로그인해 주세요.');
-          window.location.href = LOGIN_ENDPOINT;
-        }
-        return;
+      if (response.status === 400 && !alertShown) {
+        alertShown = true;
+        alert('인증이 필요한 서비스입니다. 다시 로그인해 주세요.');
+        window.location.replace(LOGIN_ENDPOINT);
       }
 
       // 다른 에러 처리
       if (!response.ok) {
         const errorData = await response.json();
-        console.error('API 응답 에러:', errorData);
+        // console.error('API 응답 에러:', errorData);
         return;
       }
 
       // 정상 응답 처리
       const res: IResponse = await response.json();
       const clubList = res.data;
-      console.log('클럽 목록 데이터:', clubList);
+      // console.log('클럽 목록 데이터:', clubList);
 
       // 클럽 목록 설정
       setClubOptions(clubList);
       // setSelectedClub(clubList[0]);
     } catch (error) {
-      console.error('담당 동호회 목록 조회 에러:', error);
+      console.error('관리 중인 동호회 목록 조회 에러:', error);
     }
   };
 
@@ -67,18 +64,33 @@ export default function ClubSelectForm() {
   }, []);
 
   // selectedClub 상태가 변경될 때마다 로그 출력
-  useEffect(() => {
-    if (selectedClub) {
-      console.log('클럽 선택됨:', {
-        clubId: selectedClub.clubId,
-        clubName: selectedClub.clubName
-      });
-    }
-  }, [selectedClub]);
+  // useEffect(() => {
+  //   if (selectedClub) {
+  //     console.log('클럽 선택됨:', {
+  //       clubId: selectedClub.clubId,
+  //       clubName: selectedClub.clubName
+  //     });
+  //   }
+  // }, [selectedClub]);
 
-  // 인증 에러 시 렌더링하지 않음
-  if (!clubOptions?.length) {  // optional chaining 추가
+  if (!clubOptions) {  // 초기 로딩 상태
     return null;
+  }
+
+  // 빈 리스트일 때 메시지 표시
+  if (clubOptions.length === 0) {
+    return (
+      <div className="space-y-9 min-w-[600px] p-8 rounded-xl bg-gray-0 shadow">
+        <div className="flex flex-col items-center py-8">
+          <h2 className="h2 font-bold text-gray-900">
+            관리 중인 동호회가 없습니다
+          </h2>
+          <span className="h4 text-gray-600 mt-4">
+            고객센터에 문의해 주시기 바랍니다
+          </span>
+        </div>
+      </div>
+    );
   }
 
   const handleSubmit = async () => {
@@ -87,10 +99,10 @@ export default function ClubSelectForm() {
     }
 
     await saveClubId(selectedClub.clubId.toString());
-    console.log('클럽 ID 저장 완료:', selectedClub.clubId.toString());
+    // console.log('클럽 ID 저장 완료:', selectedClub.clubId.toString());
 
     await saveClubName(selectedClub.clubName);
-    console.log('클럽 이름 저장 완료:', selectedClub.clubName);
+    // console.log('클럽 이름 저장 완료:', selectedClub.clubName);
 
     // 🚀 100ms 지연 후 refresh() 실행하여 쿠키 반영 대기
     setTimeout(() => {


### PR DESCRIPTION
### DESCRIPTION

- 관리 중인 동호회 선택 화면의 사용자 경험 개선
- 인증 에러 중복 알림 문제 해결


### CHANGES

1. 인증 에러 중복 알림 문제 수정
- API 응답 처리 시, 인증 오류(400) 발생 시 alert가 중복으로 나타나는 문제 해결
- alertShown 전역 변수를 사용하여 한 번만 표시하도록 수정

2. 초기 로딩 상태 처리
- clubOptions가 없는 경우 로딩 중으로 간주하고 null을 반환하여 불필요한 렌더링 방지

3. 빈 리스트 상태 처리 추가
- 관리 중인 동호회가 없을 경우 안내 메시지 출력
- "관리 중인 동호회가 없습니다"와 "고객센터에 문의해 주시기 바랍니다"를 표시하여 사용자 혼란 방지

4. UI 개선

- Tailwind CSS를 활용하여 빈 상태 메시지 스타일 추가
- 공간 배치 및 시각적 일관성 강화

### SCREENSHOTS

![image](https://github.com/user-attachments/assets/16418c8e-c6c3-48ab-a5a1-7f3acbc02285)
![image](https://github.com/user-attachments/assets/a8daca2a-17f9-4c30-b992-638a06c63378)
![image](https://github.com/user-attachments/assets/74541d55-728f-4a0e-9e7c-f1f69f1de722)

### FURTHER WORK

-

Closes #151 
