### PR TITLE
Fix: 동호회 기본정보 input/textArea readOnly 추가

### DIFF
--- a/src/components/common/CustomTextarea.tsx
+++ b/src/components/common/CustomTextarea.tsx
@@ -9,7 +9,7 @@ export const CustomTextarea = forwardRef<
     id: string;
     name: string;
   }
->(({ name, id, className, rows, maxLength, ...props }, ref) => {
+>(({ name, id, className, rows, maxLength, readOnly, ...props }, ref) => {
   return (
     <textarea
       name={name}
@@ -18,6 +18,7 @@ export const CustomTextarea = forwardRef<
       rows={rows}
       className={cn(
         "flex w-full items-center truncate rounded-md border border-transparent bg-gray-100 px-3 py-4 text-lg font-medium outline-none transition duration-300 placeholder:text-gray-400 focus:border-gray-900 focus:bg-gray-50",
+        readOnly && "cursor-not-allowed",
         className
       )}
       {...props}

--- a/src/components/common/RHF/RHFTextInput.tsx
+++ b/src/components/common/RHF/RHFTextInput.tsx
@@ -17,8 +17,12 @@ import { Remove } from "@/assets/icons/action";
 
 type LabelType = ComponentProps<"label">;
 type InputType = ComponentProps<"input">;
+type TextareaType = ComponentProps<"textarea">;
 
-type Props<T extends FieldValues> = Omit<LabelType & InputType, "className"> & {
+type Props<T extends FieldValues> = Omit<
+  LabelType & InputType & TextareaType,
+  "className"
+> & {
   labelText?: string;
   name: Path<T>;
   id: string;
@@ -88,12 +92,14 @@ export default function RHFTextInput<T extends FieldValues>({
             {/* 최대값이 있을 경우와 없을 경우로 나눔 */}
             {/* 1. 최대값이 있을 경우 100자가 넘는다면 textarea로, 아니라면 input으로 */}
             {/* 2. 최대값이 없을 경우 input으로 렌더링 */}
+
             {maxLength ? (
               maxLength >= 100 ? (
                 <CustomTextarea
                   className={inputStyle}
                   id={name}
                   rows={rows}
+                  {...props}
                   {...field}
                   maxLength={maxLength}
                   onFocus={handleFocus}

--- a/src/components/dashboard/club/manage/atoms/ActivitySchedule.tsx
+++ b/src/components/dashboard/club/manage/atoms/ActivitySchedule.tsx
@@ -20,7 +20,7 @@ export default function ActivitySchedule() {
   }) as string;
   const activityPlan = useWatch<ClubIndexSchemaType>({
     name: "activityPlan",
-  }) as string; 
+  }) as string;
   console.log("6. ActivitySchedule 실행됨");
 
   const [modalIsOpen, setModalIsOpen] = useState<boolean>(false);
@@ -52,9 +52,11 @@ export default function ActivitySchedule() {
   // }, [activityPlanDays, activityPlanFrequency, activityTime]);
 
   useEffect(() => {
-    if (typeof activityPlan === "string") { 
+    if (typeof activityPlan === "string") {
       // activityPlan 파싱
-      const [days, frequency, time] = activityPlan.split('/').map(item => item.trim());
+      const [days, frequency, time] = activityPlan
+        .split("/")
+        .map((item) => item.trim());
 
       // 포맷된 활동 일정 설정
       setFormattedActivityPlan(`${days} / ${frequency} / ${time}`);

--- a/src/components/dashboard/club/manage/molecules/ClubBasicInfo.tsx
+++ b/src/components/dashboard/club/manage/molecules/ClubBasicInfo.tsx
@@ -9,7 +9,9 @@ import { ClubIndexData } from "@/api/types/club";
 
 export default function ClubBasicInfo({ clubId }: { clubId: string | null }) {
   console.log("5. ClubBasicInfo 실행됨");
-  const [clubBasicInfo, setClubBasicInfo] = useState<ClubIndexData | null>(null);
+  const [clubBasicInfo, setClubBasicInfo] = useState<ClubIndexData | null>(
+    null
+  );
 
   useEffect(() => {
     const fetchClubBasicInfo = async () => {
@@ -42,6 +44,7 @@ export default function ClubBasicInfo({ clubId }: { clubId: string | null }) {
         labelText="동호회명"
         placeholder="예) 에너제틱 산악 동호회"
         autoComplete="off"
+        readOnly
         inputStyle="pr-9"
       />
       {/* 이 카테고리는 또 바꿔야함 */}
@@ -50,6 +53,7 @@ export default function ClubBasicInfo({ clubId }: { clubId: string | null }) {
         name="category"
         labelText="카테고리"
         autoComplete="off"
+        readOnly
         inputStyle="pr-9"
       />
 
@@ -59,6 +63,7 @@ export default function ClubBasicInfo({ clubId }: { clubId: string | null }) {
         labelText="설립 목적"
         placeholder="예) 임직원 단합을 위한 건강한 산악 모임"
         autoComplete="off"
+        readOnly
         inputStyle="pr-9"
       />
 
@@ -68,6 +73,7 @@ export default function ClubBasicInfo({ clubId }: { clubId: string | null }) {
         labelText="한줄 소개"
         autoComplete="off"
         maxLength={18}
+        readOnly
         inputStyle="pr-9"
       />
 
@@ -78,6 +84,8 @@ export default function ClubBasicInfo({ clubId }: { clubId: string | null }) {
         autoComplete="off"
         maxLength={300}
         rows={1}
+        readOnly
+        disabled
         inputStyle="resize-y"
       />
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -46,15 +46,18 @@ export function getPageRange(num: number) {
 
 export const formatDate = (date: Date | undefined) => {
   if (!date || isNaN(date.getTime())) {
-    return '';
+    return "";
   }
   // 한국 시간으로 변환
-  const koreaDate = new Date(date.getTime() + (9 * 60 * 60 * 1000));
-  return koreaDate.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
-  }).replace(/\. /g, '-').replace('.', '');
+  const koreaDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return koreaDate
+    .toLocaleDateString("ko-KR", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+    .replace(/\. /g, "-")
+    .replace(".", "");
 };
 
 export function formatTime(date: Date | undefined, withIndicator?: boolean) {


### PR DESCRIPTION
### DESCRIPTION

- 기본정보들이 수정할 수 있을것 처럼 커서 형성이 되어 있습니다.
   그래서 동호회 임원 유저들이 수정을 시도한다고 하납니다.
   수정 x > 조회만 가능하도록  해주세요!

### CHANGES
- components/dashboard/club/manage/molecules/ClubBasicInfo.tsx
  -  input/textArea reactOnly 속성 추가
- components/common/RHF/RHFTextInput.tsx
  - Props textArea 타입 추가,

### SCREENSHOTS

- 스크린샷은 생략하겠습니다.

### FURTHER WORK

- x

Closes #193 
