### PR TITLE
feat: 활동보고서 작성 기능 개선 및 데이터 복원 로직 수정

### DIFF
--- a/src/app/club/dashboard/result-report/page.tsx
+++ b/src/app/club/dashboard/result-report/page.tsx
@@ -3,7 +3,7 @@ import ResultReportFormProvider from "@/components/dashboard/club/result-report/
 
 const ResultReportPage = async () => {
   return (
-    <main className="flex gap-3">
+    <main className="flex gap-3 justify-center">
       <ClubInfoCard />
       <ResultReportFormProvider />
     </main>

--- a/src/components/common/RHF/RHFTextInput.tsx
+++ b/src/components/common/RHF/RHFTextInput.tsx
@@ -21,7 +21,7 @@ type TextareaType = ComponentProps<"textarea">;
 
 type Props<T extends FieldValues> = Omit<
   LabelType & InputType & TextareaType,
-  "className"
+  "className" | "type"
 > & {
   labelText?: string;
   name: Path<T>;
@@ -30,6 +30,7 @@ type Props<T extends FieldValues> = Omit<
   labelStyle?: string;
   inputStyle?: string;
   rows?: number;
+  type?: React.HTMLInputTypeAttribute;
 };
 
 export default function RHFTextInput<T extends FieldValues>({
@@ -41,6 +42,7 @@ export default function RHFTextInput<T extends FieldValues>({
   rows,
   labelStyle,
   inputStyle,
+  type: propsType,
   ...props
 }: Props<T>) {
   const {
@@ -49,134 +51,137 @@ export default function RHFTextInput<T extends FieldValues>({
     formState: { errors },
   } = useFormContext<T>();
 
-  // console.log(errors);
-
-  const value = useWatch<T>({ name: name });
-
-  // CustomInput의 컴포넌트는 forwardRef를 사용하여 ref가 function으로 할당되었음
-  // 비제어 컴포넌트로 관리하기 때문에 focus, blur 이벤트를 부모에서 관리하여 props로 넘겨주도록 결정
+  const value = useWatch<T>({ name });
   const [isFocusing, setIsFocusing] = useState<boolean>(false);
 
-  const handleFocus = () => {
-    setIsFocusing(true);
+  const formatNumber = (val: unknown): string => {
+    if (val === undefined || val === null || val === "") return "";
+    const stringVal = String(val);
+    return stringVal.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
   };
 
-  const handleBlur = () => {
-    setIsFocusing(false);
+  const unformatNumber = (val: string): string => {
+    return val.replace(/[^\d]/g, "");
   };
+
+  const handleFocus = () => setIsFocusing(true);
+  const handleBlur = () => setIsFocusing(false);
 
   const handleDelete = () => {
-    setValue(name, "" as PathValue<T, Path<T>>);
+    setValue(name, "" as PathValue<T, Path<T>>, { shouldValidate: true });
   };
 
-  // 에러 메시지 가져오기
   const getErrorMessage = () => {
     const nameParts = name.split(".");
     let currentErrors: any = errors;
 
     for (const part of nameParts) {
-      if (currentErrors && currentErrors[part]) {
+      if (currentErrors?.[part]) {
         currentErrors = currentErrors[part];
       } else {
         return undefined;
       }
     }
-
     return currentErrors?.message?.toString();
   };
 
   const errorMessage = getErrorMessage();
+  const isNumberType = propsType === "number";
 
   return (
     <Controller
       name={name}
       control={control}
-      render={({ field }) => (
-        <div className="flex flex-col gap-2">
-          {labelText && (
-            <div className="flex items-center justify-between">
-              <CustomLabel
-                htmlFor={id}
-                labelText={labelText}
-                required={required}
-                className={labelStyle}
-              />
-              {maxLength && (
-                <span className="text-base font-medium text-gray-600">
-                  {value?.length ?? 0}자/{maxLength}자
-                </span>
-              )}
-            </div>
-          )}
+      render={({ field: { onChange, value: fieldValue, ...fieldProps } }) => {
+        const handleValueChange = (
+          e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+        ) => {
+          if (isNumberType) {
+            const rawValue = unformatNumber(e.target.value);
+            onChange(rawValue);
+          } else {
+            onChange(e.target.value);
+          }
+        };
 
-          <div className="relative">
-            {/* 최대값이 있을 경우와 없을 경우로 나눔 */}
-            {/* 1. 최대값이 있을 경우 100자가 넘는다면 textarea로, 아니라면 input으로 */}
-            {/* 2. 최대값이 없을 경우 input으로 렌더링 */}
+        const displayValue = isNumberType
+          ? formatNumber(fieldValue)
+          : (fieldValue ?? "");
 
-            {maxLength ? (
-              maxLength >= 100 ? (
+        return (
+          <div className="flex flex-col gap-2">
+            {labelText && (
+              <div className="flex items-center justify-between">
+                <CustomLabel
+                  htmlFor={id}
+                  labelText={labelText}
+                  required={required}
+                  className={labelStyle}
+                />
+                {maxLength && (
+                  <span className="text-base font-medium text-gray-600">
+                    {String(fieldValue || "").length}자/{maxLength}자
+                  </span>
+                )}
+              </div>
+            )}
+
+            <div className="relative">
+              {maxLength && maxLength >= 100 ? (
                 <CustomTextarea
-                  className={inputStyle}
-                  id={name}
-                  rows={rows}
+                  {...fieldProps}
                   {...props}
-                  {...field}
+                  id={id}
+                  className={inputStyle}
+                  rows={rows}
                   maxLength={maxLength}
+                  value={displayValue as string}
+                  onChange={handleValueChange}
                   onFocus={handleFocus}
                   onBlur={handleBlur}
                 />
               ) : (
                 <CustomTextInput
-                  className={inputStyle}
-                  id={id}
-                  {...field}
+                  {...fieldProps}
                   {...props}
+                  id={id}
+                  className={cn(inputStyle, isNumberType && "text-right pr-10")}
                   required={required}
                   maxLength={maxLength}
+                  value={displayValue as string}
+                  onChange={handleValueChange}
                   onFocus={handleFocus}
                   onBlur={handleBlur}
+                  {...({
+                    type: isNumberType ? "text" : propsType,
+                    inputMode: isNumberType ? "numeric" : props.inputMode,
+                  } as any)}
                 />
-              )
-            ) : (
-              <CustomTextInput
-                className={inputStyle}
-                id={id}
-                {...field}
-                {...props}
-                required={required}
-                maxLength={maxLength}
-                onFocus={handleFocus}
-                onBlur={handleBlur}
-              />
-            )}
-            {!props.readOnly && (
-              <button
-                type="button"
-                className={cn(
-                  "absolute right-3 top-2/4 z-10 h-5 w-5 -translate-y-1/2",
-                  isFocusing ? "visible" : "hidden"
-                )}
-                onClick={handleDelete}
-                onMouseDown={(e) => e.preventDefault()}
-              >
-                <Remove className="h-full w-full text-gray-500" />
-              </button>
+              )}
+
+              {/* {!props.readOnly && (
+                <button
+                  type="button"
+                  className={cn(
+                    "absolute right-3 top-2/4 z-10 h-5 w-5 -translate-y-1/2",
+                    isFocusing ? "visible" : "hidden"
+                  )}
+                  onClick={handleDelete}
+                  onMouseDown={(e) => e.preventDefault()}
+                >
+                  <Remove className="h-full w-full text-gray-500" />
+                </button>
+              )} */}
+            </div>
+
+            {errorMessage && (
+              <div className="text-base font-medium text-point-red">
+                {errorMessage}
+              </div>
             )}
           </div>
-
-          {/* {errors[name] && (
-            <div className="text-base font-medium text-point-red">
-              {errors[name].message?.toString()}
-            </div>
-          )} */}
-          {!errors[name] && errorMessage && (
-            <div className="text-base font-medium text-point-red">
-              {errorMessage}
-            </div>
-          )}
-        </div>
-      )}
+        );
+      }}
     />
   );
 }

--- a/src/components/dashboard/club/report/molecules/ReportTable.tsx
+++ b/src/components/dashboard/club/report/molecules/ReportTable.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { cn } from "@/lib/utils";
-import type { IResponse } from "@/api/types/index"; // ✅ import 추가
+import type { IResponse } from "@/api/types/index";
 
 const tableHeadings = ["순번", "활동명", "활동일", "작성 상태", "반려 사유"];
 
@@ -15,7 +15,7 @@ interface ReportItem {
 }
 
 interface Props {
-  data?: IResponse[]; // ✅ 간단하게 변경
+  data?: IResponse[];
   clubId: string | undefined;
   currentPage: number;
 }
@@ -24,7 +24,6 @@ export default function ReportTable({ data, clubId, currentPage }: Props) {
   const pathname = usePathname();
   const { push } = useRouter();
 
-  // ✅ 타입 체크 추가
   const currentPageData = data?.find(
     (item) => item.data?.currentPage === currentPage
   )?.data?.list as ReportItem[] | undefined;
@@ -113,7 +112,7 @@ export default function ReportTable({ data, clubId, currentPage }: Props) {
         ))
       ) : (
         <li className="flex items-center justify-center h-[200px] text-gray-500">
-          조회된 보고서가 없습니다.
+          작성 및 제출 된 활동보고서가 없습니다.
         </li>
       )}
     </ul>

--- a/src/components/dashboard/club/report/organisms/NewReportForm.tsx
+++ b/src/components/dashboard/club/report/organisms/NewReportForm.tsx
@@ -28,7 +28,7 @@ export default function NewReportForm() {
   return (
     <form className="space-y-3 w-full" onSubmit={handleSubmit}>
       <div className="flex flex-col gap-6 p-8 rounded-xl bg-gray-0">
-        <h3 className="h2 font-bold text-gray-900">{"기본 정보"}</h3>
+        <h3 className="h2 font-bold text-gray-900">기본 정보</h3>
         <Input
           name="clubName"
           label="동호회명"
@@ -37,9 +37,7 @@ export default function NewReportForm() {
           readOnly
         />
         <div className="flex flex-col gap-2">
-          <span className="h3 font-semibold text-gray-900">
-            {"동호회 임원"}
-          </span>
+          <span className="h3 font-semibold text-gray-900">동호회 임원</span>
           <Input
             name="clubAdmin1"
             type="text"
@@ -72,8 +70,8 @@ export default function NewReportForm() {
           name="image"
           label="활동 사진"
           caption="활동사진 첨부 필수사항입니다."
-		  currentImages={currentImages}
-		  setCurrentImages={setCurrentImages}
+          currentImages={currentImages}
+          setCurrentImages={setCurrentImages}
         />
         <Input
           name="note"
@@ -84,9 +82,7 @@ export default function NewReportForm() {
         />
       </div>
       <div className="flex flex-col gap-6 p-8 rounded-xl bg-gray-0">
-        <h3 className="h2 font-bold text-gray-900">
-          {"활동 지출 내역 및 증빙"}
-        </h3>
+        <h3 className="h2 font-bold text-gray-900">활동 지출 내역 및 증빙</h3>
         <div className="flex flex-col gap-2">
           <span className="h3 font-semibold text-gray-900">{"전표 일자"}</span>
           <DatePicker
@@ -129,8 +125,8 @@ export default function NewReportForm() {
           name="expense-image"
           label="지출 증빙용 활동 사진 첨부"
           caption="활동사진 첨부 필수사항입니다."
-		  currentImages={currentImagesExpense}
-		  setCurrentImages={setCurrentImagesExpense}
+          currentImages={currentImagesExpense}
+          setCurrentImages={setCurrentImagesExpense}
         />
       </div>
       <div className="flex flex-col gap-6 p-8 rounded-xl bg-gray-0">

--- a/src/components/dashboard/club/result-report/atom/image-input.tsx
+++ b/src/components/dashboard/club/result-report/atom/image-input.tsx
@@ -2,7 +2,6 @@ import { useRef, useState } from "react";
 import { File } from "@/assets/icons/action";
 import { CustomLabel } from "@/components/common/CustomLabel";
 import { useFormContext } from "react-hook-form";
-import { ResultReportSchemaType } from "@/lib/types/schema";
 
 const ImageInput = ({ idx }: { idx: number }) => {
   const { setValue, watch } = useFormContext();
@@ -18,7 +17,6 @@ const ImageInput = ({ idx }: { idx: number }) => {
     setFileName(e.target.files[0].name);
     const currentReceipts = watch("receipts") || [];
 
-    // setValue(`receipts`, [URL.createObjectURL(e.target.files[0])]);
     setValue("receipts", [...currentReceipts, e.target.files[0]]); // File 객체로 저장
   };
 
@@ -45,6 +43,9 @@ const ImageInput = ({ idx }: { idx: number }) => {
           <File className="text-gray-400" />
         </div>
       </div>
+      <p className="text-base font-medium text-gray-500 mt-1">
+        *jpg, png 등 이미지 파일만 가능
+      </p>
     </div>
   );
 };

--- a/src/components/dashboard/club/result-report/molecules/AutoSaveRestoreAlert.tsx
+++ b/src/components/dashboard/club/result-report/molecules/AutoSaveRestoreAlert.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect } from "react";
 import { useAutoSave } from "@/hooks/useAutoSave";
 import { UseFormReturn } from "react-hook-form";
 import { useToast } from "@/components/common/ToastContainer";
-import { Checked } from "@/assets/icons/checkbox";
 
 interface Props {
   form: UseFormReturn<any>;

--- a/src/components/dashboard/club/result-report/molecules/ResultReportMemberCount.tsx
+++ b/src/components/dashboard/club/result-report/molecules/ResultReportMemberCount.tsx
@@ -43,6 +43,15 @@ const ResultReportMemberCount = () => {
     setValue("data.participantCount", memberCount, { shouldValidate: true });
   }, [memberCount]);
 
+  const participantCount = watch("data.participantCount");
+
+  useEffect(() => {
+    if (participantCount !== undefined && participantCount !== memberCount) {
+      setMemberCount(participantCount);
+      setInputValue(participantCount === 0 ? "" : participantCount.toString());
+    }
+  }, [participantCount]);
+
   // 에러 메시지 가져오기
   const getErrorMessage = () => {
     const nameParts = "data.participantCount".split(".");

--- a/src/components/dashboard/club/result-report/organisms/ResultReportAccounts.tsx
+++ b/src/components/dashboard/club/result-report/organisms/ResultReportAccounts.tsx
@@ -64,7 +64,7 @@ const ResultReportAccountsForm = () => {
             <div className="w-1/4 flex flex-col gap-2 h-full">
               <CustomLabel
                 htmlFor={`data.expenses.${idx}.category`}
-                labelText={"과목"}
+                labelText="과목"
                 required={true}
               />
               <DropdownSelect
@@ -145,7 +145,7 @@ const ResultReportAccountsForm = () => {
             <div className="flex flex-col gap-2">
               <CustomLabel
                 htmlFor={`data.expenses.${idx}.issuedDate`}
-                labelText={"일자"}
+                labelText="일자"
                 required={true}
               />
               <DatePicker
@@ -217,7 +217,7 @@ const ResultReportAccountsForm = () => {
         <span
           className={cn("h3 font-bold transition duration-200 text-orange-500")}
         >
-          + 정산서 추가하기
+          + 영수증 추가하기
         </span>
       </button>
       {/* </Card> */}

--- a/src/components/dashboard/club/result-report/organisms/ResultReportPhotCard.tsx
+++ b/src/components/dashboard/club/result-report/organisms/ResultReportPhotCard.tsx
@@ -102,7 +102,7 @@ const ResultReportPhotCard = () => {
         </button>
 
         <p className="text-sm text-gray-500">
-          활동사진 첨부 필수사항입니다. 최대 4장까지 첨부 가능합니다.
+          활동사진을 첨부해주세요. (최대 4장 / jpg, png 등 이미지 파일만 가능)
         </p>
 
         {errorMessage && (


### PR DESCRIPTION


### DESCRIPTION

활동보고서 작성 프로세스에서 발생하는 데이터 유실 문제를 해결하고, 사용자 요구사항 적용

### CHANGES

- 숫자 입력 포맷팅: RHFTextInput에 type="number" 설정 시 실시간으로 천 단위 구분자(,)가 표시되도록 기능을 확장했습니다. (내부적으로는 숫자형 데이터 유지)
- Textarea 최적화: maxLength가 100자 이상인 Textarea 모드에서는 입력창을 가리지 않도록 삭제(Clear) 버튼을 숨김 처리했습니다.
- 이미지 업로드 가이드: 이미지 첨부 컴포넌트 하단에 허용 확장자(*jpg, png 등) 안내 문구를 추가했습니다.
- 빈 목록 대응: 등록된 활동보고서가 없을 경우, 사용자에게 홍보를 유도하는 안내 섹션을 추가했습니다.

